### PR TITLE
Support sites with restrictive CSP policies

### DIFF
--- a/src/nodeSavePageWE.js
+++ b/src/nodeSavePageWE.js
@@ -33,6 +33,9 @@ module.exports = {
             height: 10000
         });
 
+        // Allow injected scripts to be executed
+        await page.setBypassCSP(true);
+
         await page.goto(task.url, { timeout: 180000, waitUntil: ['domcontentloaded'] });
 
 


### PR DESCRIPTION
Thanks for maintaining this repo!

I noticed that pages like `https://github.com` would fail with `[ReferenceError]: runSinglePage is not defined`. Checking the browser console led me to discover that the `nodeSavePageWE_client.js` script is not getting executed due to the restrictive CSP on the page.

Using `page.setBypassCSP(true)` allows `https://github.com` to be successfully saved.