### PR TITLE
Support running outside of `src` directory

### DIFF
--- a/src/nodeSavePageWE.js
+++ b/src/nodeSavePageWE.js
@@ -16,6 +16,7 @@ module.exports = {
     scrape: async function (task) {
 
         const fs = require('fs');
+        const path = require('path');
         const puppeteer = require('puppeteer');
 
         require('events').EventEmitter.defaultMaxListeners = 50;
@@ -36,7 +37,7 @@ module.exports = {
         await page.goto(task.url, { timeout: 180000, waitUntil: ['domcontentloaded'] });
 
 
-        await page.addScriptTag({ path: "nodeSavePageWE_client.js" });
+        await page.addScriptTag({ path: path.join(__dirname, 'nodeSavePageWE_client.js') });
 
 
         await page.evaluate(async (params) => { 


### PR DESCRIPTION
Running from anywhere other than `src` causes the following error:
```
ENOENT: no such file or directory, open 'nodeSavePageWE_client.js'
```

This can be resolved by using a path relative to `__dirname`, i.e. the directory the `nodeSavePageWE.js` file is located in.